### PR TITLE
Rework dockerization so that it uses multi-stage docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 *
 !cmd/
 !vendor/
-!http-gateway-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
+FROM golang:1.9 as builder
+
+ARG PACKAGE=github.com/projectriff/http-gateway
+ARG COMMAND=cmd/http-gateway.go
+
+WORKDIR /go/src/${PACKAGE}
+COPY vendor/ vendor/
+COPY cmd/ cmd/
+RUN CGO_ENABLED=0 go build -v -a -installsuffix cgo ${COMMAND}
+
+###########
+
 FROM scratch
 
-ADD http-gateway-linux /http-gateway
+ARG PACKAGE=github.com/projectriff/http-gateway
+COPY --from=builder /go/src/${PACKAGE}/http-gateway /http-gateway
 
 CMD ["/http-gateway"]

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,25 @@
-.PHONY: build build-for-docker clean dockerize
+.PHONY: build clean dockerize test
 OUTPUT = http-gateway
-OUTPUT_LINUX = http-gateway-linux
-BUILD_FLAGS =
 
-ifeq ($(OS),Windows_NT)
-    detected_OS := Windows
-else
-    detected_OS := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-endif
-
-ifeq ($(detected_OS),Linux)
-        BUILD_FLAGS += -ldflags "-linkmode external -extldflags -static"
-endif
-
-GO_SOURCES = $(shell find pkg cmd -type f -name '*.go')
+GO_SOURCES = $(shell find cmd -type f -name '*.go')
 TAG = 0.0.4-snapshot
 
 build: $(OUTPUT)
 
-build-for-docker: $(OUTPUT_LINUX)
-
 test: build
 	go test -v ./...
 
-.arch-linux: vendor
-
 $(OUTPUT): $(GO_SOURCES) vendor
 	go build cmd/http-gateway.go
-
-$(OUTPUT_LINUX): $(GO_SOURCES) vendor
-	# This builds the executable from Go sources on *your* machine, targeting Linux OS
-	# and linking everything statically, to minimize Docker image size
-	# See e.g. https://blog.codeship.com/building-minimal-docker-containers-for-go-applications/ for details
-	CGO_ENABLED=0 GOOS=linux go build $(BUILD_FLAGS) -v -a -installsuffix cgo -o $(OUTPUT_LINUX) cmd/http-gateway.go
 
 vendor: Gopkg.toml
 	dep ensure
 
 clean:
 	rm -f $(OUTPUT)
-	rm -f $(OUTPUT_LINUX)
 
-dockerize: build-for-docker
-	docker build . -t projectriff/http-gateway:0.0.4-snapshot
+dockerize: $(GO_SOURCES) vendor
+	docker build . -t projectriff/http-gateway:$(TAG)
 
 debug-dockerize: $(GO_SOURCES) vendor
 	# Need to remove probes as delve starts app in paused state


### PR DESCRIPTION
This gets rid of some tricks to build for linux while on other OS (typically MacOS laptop).

Need to discuss how this would integrate with CI (and docker resource).
Ping @jchesterpivotal 