### PR TITLE
Send a 500 when a function errors

### DIFF
--- a/pkg/server/requests_handler.go
+++ b/pkg/server/requests_handler.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	CorrelationId = "correlationId"
+	Error         = "error"
 	requestPath   = "/requests/"
 )
 
@@ -63,6 +64,12 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case reply := <-replyChan:
+		replyError := reply.Headers().GetOrDefault(Error, "")
+		if len(replyError) != 0 {
+			// message is an error
+			// TODO set status code based on replyError type
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 		propagateOutgoingHeaders(reply, w)
 		w.Write(reply.Payload())
 	case <-time.After(g.timeout):


### PR DESCRIPTION
If the correlated response message contains an 'error' header, the
request failed within the function invoker. The http-gateway will now
respond with an HTTP 500 error to indicate to the caller that the
request failed.

fixes #22